### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   dotnet:
+    permissions:
+      contents: read
     uses: mathieumack/MyGithubActions/.github/workflows/dotnetlib.yml@main
     with:
       publishToNuget: ${{ github.event.inputs.publishToNuget == true }}


### PR DESCRIPTION
Potential fix for [https://github.com/mathieumack/MarkdownToDocxGenerator/security/code-scanning/1](https://github.com/mathieumack/MarkdownToDocxGenerator/security/code-scanning/1)

In general, the fix is to explicitly specify a `permissions` block in the workflow (either at the top level or for the `dotnet` job) so the GITHUB_TOKEN is limited to the least privileges required. When using reusable workflows via `uses: owner/repo/.github/workflows/file.yml@ref`, the caller can and should still set `permissions` for the job that invokes the reusable workflow; these permissions will apply to that job and therefore to the reusable workflow’s execution context.

The best minimal change here is to add a `permissions` block under the `dotnet` job, before `uses:`. Given the information available, we cannot know all precise permissions required by the reusable workflow, so we should start from a safe baseline of read-only repository access: `contents: read`. This aligns with the CodeQL suggestion to specify explicit minimal permissions and does not change existing functionality in most typical .NET CI scenarios, which often only need to read the repository content. If later the reusable workflow is found to require additional scopes (e.g., `packages: write` or `contents: write`), those can be added explicitly. No extra imports or external definitions are needed; we only modify the YAML structure in `.github/workflows/ci.yml`.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Within `jobs.dotnet`, add:

```yaml
    permissions:
      contents: read
```

- Place this block between `dotnet:` and `uses:` to keep the structure clear and standard.
- No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
