### PR TITLE
Render inline `code` spans, add tests, and move deps to stable releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,12 @@ This library uses the following packages:
 In your `Program.cs` or `Startup.cs`:
 
 ```csharp
-services.AddMarkdownToDocxGenerator();
-
-// Or for advanced control:
-// services.RegisterMarkdownToDocxGenerator(asSingleton: true);
+// asSingleton: true  -> services registered as singletons
+// asSingleton: false -> services registered as transient
+services.RegisterMarkdownToDocxGenerator(asSingleton: true);
 ```
 
-> **⚠️ Important**: You must register a logger (`ILogger`) before calling `AddMarkdownToDocxGenerator`.
+> **⚠️ Important**: You must register a logger (`ILogger`) before calling `RegisterMarkdownToDocxGenerator` — the generator depends on `ILogger<>`.
 
 #### 2. Inject and Use the Generator
 

--- a/src/MarkdownToDocxGenerator.Console/MarkdownToDocxGenerator.Console.csproj
+++ b/src/MarkdownToDocxGenerator.Console/MarkdownToDocxGenerator.Console.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenXMLSDK.Engine" Version="2022.10313.0-preview-044" />
+    <PackageReference Include="OpenXMLSDK.Engine" Version="2022.10313.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MarkdownToDocxGenerator.UnitTests/MarkdownToDocxGenerator.UnitTests.csproj
+++ b/src/MarkdownToDocxGenerator.UnitTests/MarkdownToDocxGenerator.UnitTests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.0-preview.25454.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.0-preview.25454.2" />
-    <PackageReference Include="OpenXMLSDK.Engine" Version="2022.10313.0-preview-044" />
+    <PackageReference Include="OpenXMLSDK.Engine" Version="2022.10313.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MarkdownToDocxGenerator.UnitTests/MarkdownToDocxIntegrationTests.cs
+++ b/src/MarkdownToDocxGenerator.UnitTests/MarkdownToDocxIntegrationTests.cs
@@ -1,0 +1,69 @@
+using DocumentFormat.OpenXml.Packaging;
+using MarkdownToDocxGenerator.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MarkdownToDocxGenerator.UnitTests
+{
+    /// <summary>
+    /// Tests the DI registration contract and the full end-to-end pipeline
+    /// (markdown -> in-memory DOCX) via <see cref="MdReportGenenerator"/>.
+    /// </summary>
+    [TestClass]
+    public class MarkdownToDocxIntegrationTests
+    {
+        private static ServiceProvider BuildProvider(bool asSingleton)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging(c => c.AddConsole());
+            services.RegisterMarkdownToDocxGenerator(asSingleton);
+            return services.BuildServiceProvider();
+        }
+
+        [TestMethod]
+        public void Register_as_singleton_resolves_the_same_instance()
+        {
+            using var provider = BuildProvider(asSingleton: true);
+
+            var first = provider.GetRequiredService<MdToOxmlEngine>();
+            var second = provider.GetRequiredService<MdToOxmlEngine>();
+            Assert.AreSame(first, second);
+        }
+
+        [TestMethod]
+        public void Register_as_transient_resolves_new_instances()
+        {
+            using var provider = BuildProvider(asSingleton: false);
+
+            var first = provider.GetRequiredService<MdToOxmlEngine>();
+            var second = provider.GetRequiredService<MdToOxmlEngine>();
+            Assert.AreNotSame(first, second);
+        }
+
+        [TestMethod]
+        public void Generator_resolves_with_its_full_dependency_graph()
+        {
+            using var provider = BuildProvider(asSingleton: true);
+
+            // Throws if MdReportGenenerator / MdToOxmlEngine / ILogger<> are not all wired up.
+            var generator = provider.GetRequiredService<MdReportGenenerator>();
+            Assert.IsNotNull(generator);
+        }
+
+        [TestMethod]
+        public void TransformWithStream_produces_a_valid_docx_containing_the_text()
+        {
+            using var provider = BuildProvider(asSingleton: true);
+            var generator = provider.GetRequiredService<MdReportGenenerator>();
+
+            using var stream = generator.TransformWithStream(new List<string> { "# Hello World" });
+
+            Assert.IsGreaterThan(0, stream.Length, "generated stream should not be empty");
+
+            stream.Position = 0;
+            using var document = WordprocessingDocument.Open(stream, false);
+            var text = document.MainDocumentPart?.Document?.InnerText ?? string.Empty;
+            StringAssert.Contains(text, "Hello World");
+        }
+    }
+}

--- a/src/MarkdownToDocxGenerator.UnitTests/MdToOxmlEngineTests.cs
+++ b/src/MarkdownToDocxGenerator.UnitTests/MdToOxmlEngineTests.cs
@@ -1,0 +1,218 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenXMLSDK.Engine.Word.ReportEngine;
+using OpenXMLSDK.Engine.Word.ReportEngine.Models;
+
+namespace MarkdownToDocxGenerator.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the markdown -> OXML document-model mapping performed by
+    /// <see cref="MdToOxmlEngine"/>. These assert the produced <see cref="Report"/>
+    /// model directly (no files, no template), so they are fast and deterministic.
+    /// </summary>
+    [TestClass]
+    public class MdToOxmlEngineTests
+    {
+        private static MdToOxmlEngine CreateEngine()
+            => new MdToOxmlEngine(NullLogger<MdToOxmlEngine>.Instance);
+
+        private static Page FirstPage(Report report)
+            => (Page)report.Document.Pages.Single();
+
+        private static IEnumerable<Label> Labels(Page page)
+            => page.ChildElements.OfType<Paragraph>().SelectMany(p => p.ChildElements.OfType<Label>());
+
+        [TestMethod]
+        [DataRow(1, "Titre1", DisplayName = "H1 -> Titre1")]
+        [DataRow(2, "Titre2", DisplayName = "H2 -> Titre2")]
+        [DataRow(3, "Titre3", DisplayName = "H3 -> Titre3")]
+        public void Heading_maps_to_Titre_style(int level, string expectedStyle)
+        {
+            var markdown = new string('#', level) + " Heading text";
+
+            var report = CreateEngine().Transform(markdown, "");
+
+            var paragraph = FirstPage(report).ChildElements.OfType<Paragraph>().First();
+            Assert.AreEqual(expectedStyle, paragraph.ParagraphStyleId);
+            Assert.AreEqual("Heading text", paragraph.ChildElements.OfType<Label>().First().Text);
+        }
+
+        [TestMethod]
+        public void Bold_text_produces_a_bold_label()
+        {
+            var report = CreateEngine().Transform("**bold words**", "");
+
+            var label = Labels(FirstPage(report)).Single(l => l.Text == "bold words");
+            Assert.IsTrue(label.Bold!.Value);
+        }
+
+        [TestMethod]
+        public void Plain_paragraph_text_is_not_bold()
+        {
+            var report = CreateEngine().Transform("Just some text", "");
+
+            var label = Labels(FirstPage(report)).First();
+            Assert.AreEqual("Just some text", label.Text);
+            Assert.IsFalse(label.Bold!.Value);
+        }
+
+        [TestMethod]
+        public void Fenced_code_block_lines_get_grey_shading()
+        {
+            var markdown = "```\nvar x = 1;\n```";
+
+            var report = CreateEngine().Transform(markdown, "");
+
+            var codeParagraphs = FirstPage(report).ChildElements
+                .OfType<Paragraph>()
+                .Where(p => p.Shading == "EAEAEA")
+                .ToList();
+
+            Assert.IsGreaterThanOrEqualTo(1, codeParagraphs.Count, "expected at least one shaded code paragraph");
+            Assert.IsTrue(
+                codeParagraphs.SelectMany(p => p.ChildElements.OfType<Label>()).Any(l => l.Text.Contains("var x = 1;")),
+                "code text should be preserved in a shaded paragraph");
+        }
+
+        [TestMethod]
+        public void Pipe_table_produces_a_table_with_header_and_data_rows()
+        {
+            var markdown = "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |";
+
+            var report = CreateEngine().Transform(markdown, "");
+
+            var table = FirstPage(report).ChildElements.OfType<Table>().Single();
+            Assert.HasCount(2, table.HeaderRow.Cells, "header should have two columns");
+            Assert.HasCount(2, table.Rows, "two data rows expected (header excluded)");
+        }
+
+        [TestMethod]
+        public void Absolute_url_link_becomes_a_hyperlink()
+        {
+            var report = CreateEngine().Transform("[Google](https://www.google.com)", "");
+
+            var hyperlink = FirstPage(report).ChildElements
+                .OfType<Paragraph>()
+                .SelectMany(p => p.ChildElements.OfType<Hyperlink>())
+                .Single();
+
+            Assert.AreEqual("https://www.google.com", hyperlink.WebSiteUri);
+        }
+
+        [TestMethod]
+        public void Relative_link_falls_back_to_a_plain_label_not_a_hyperlink()
+        {
+            // Regression guard for #25: relative paths are not well-formed absolute URIs
+            // and must render as plain text, never as a (broken) hyperlink.
+            var report = CreateEngine().Transform("[see file](relative/path.md)", "");
+
+            var paragraphs = FirstPage(report).ChildElements.OfType<Paragraph>().ToList();
+            var hyperlinks = paragraphs.SelectMany(p => p.ChildElements.OfType<Hyperlink>()).ToList();
+            var labels = paragraphs.SelectMany(p => p.ChildElements.OfType<Label>()).ToList();
+
+            Assert.IsEmpty(hyperlinks, "relative URLs must not become hyperlinks");
+            Assert.IsTrue(labels.Any(l => l.Text == "see file"), "link text should survive as a plain label");
+        }
+
+        [TestMethod]
+        public void Inline_code_span_content_is_preserved_as_a_label()
+        {
+            // Regression guard: inline `code` spans were silently dropped because
+            // CodeInline had no handler, so surrounding text appeared mangled.
+            var report = CreateEngine().Transform("the `Labware8` db doesn't exist", "");
+
+            var labels = Labels(FirstPage(report)).Select(l => l.Text).ToList();
+
+            Assert.IsTrue(labels.Any(t => t == "Labware8"),
+                "inline code content must survive; got: " + string.Join(" | ", labels));
+            CollectionAssert.AreEqual(
+                new[] { "the ", "Labware8", " db doesn't exist" },
+                labels,
+                "code span should sit inline between the surrounding text");
+        }
+
+        [TestMethod]
+        public void Inline_code_with_apostrophes_is_not_dropped()
+        {
+            // The original report: apostrophes inside an inline code span looked
+            // "interpreted wrong" because the whole span vanished.
+            var report = CreateEngine().Transform("all 71 `Invalid column name 'PROGRAM'` errors", "");
+
+            var labels = Labels(FirstPage(report)).Select(l => l.Text).ToList();
+
+            // Assert the whole sequence: the original symptom was the surrounding
+            // prose looking mangled because the code span (with its apostrophes) vanished.
+            CollectionAssert.AreEqual(
+                new[] { "all 71 ", "Invalid column name 'PROGRAM'", " errors" },
+                labels,
+                "code span with apostrophes must be preserved inline; got: " + string.Join(" | ", labels));
+        }
+
+        [TestMethod]
+        public void Inline_code_nested_in_emphasis_is_preserved()
+        {
+            // The emphasis sub-loop had the same missing CodeInline case, so
+            // `code` inside **bold**/*italic* was dropped.
+            var report = CreateEngine().Transform("see **the `FN_ADD_FLAG` routine**", "");
+
+            var labels = Labels(FirstPage(report)).Select(l => l.Text).ToList();
+
+            Assert.IsTrue(labels.Any(t => t == "FN_ADD_FLAG"),
+                "code span nested in emphasis must be preserved; got: " + string.Join(" | ", labels));
+        }
+
+        [TestMethod]
+        public void Inline_code_label_is_monospace_and_shaded()
+        {
+            var report = CreateEngine().Transform("a `code` span", "");
+
+            var codeLabel = Labels(FirstPage(report)).Single(l => l.Text == "code");
+            Assert.AreEqual("Consolas", codeLabel.FontName);
+            Assert.AreEqual("EAEAEA", codeLabel.Shading);
+        }
+
+        [TestMethod]
+        public void Heading_inline_code_inherits_title_style()
+        {
+            // Inline code in a heading must not carry a shaded monospace box;
+            // it should inherit the title style like the rest of the heading.
+            var report = CreateEngine().Transform("# Title with `code` here", "");
+
+            var codeLabel = Labels(FirstPage(report)).Single(l => l.Text == "code");
+            Assert.IsNull(codeLabel.Shading, "heading code must not keep code shading");
+            Assert.IsNull(codeLabel.FontName, "heading code must not keep monospace font");
+        }
+
+        [TestMethod]
+        public void Link_with_inline_code_label_is_preserved_as_hyperlink()
+        {
+            // Inline code as a link's text was dropped (hyperlink had null text).
+            var report = CreateEngine().Transform("[`code`](https://example.com)", "");
+
+            var hyperlink = FirstPage(report).ChildElements
+                .OfType<Paragraph>()
+                .SelectMany(p => p.ChildElements.OfType<Hyperlink>())
+                .Single();
+
+            Assert.AreEqual("https://example.com", hyperlink.WebSiteUri);
+            Assert.AreEqual("code", hyperlink.Text?.Text);
+        }
+
+        [TestMethod]
+        public void Empty_absolute_link_does_not_throw()
+        {
+            // Regression guard: an empty-text absolute link `[](url)` used to
+            // throw NullReferenceException on FirstChild.
+            var report = CreateEngine().Transform("[](https://example.com)", "");
+
+            Assert.IsNotNull(report);
+        }
+
+        [TestMethod]
+        public void Empty_markdown_produces_a_page_with_no_elements()
+        {
+            var report = CreateEngine().Transform("", "");
+
+            Assert.IsEmpty(FirstPage(report).ChildElements);
+        }
+    }
+}

--- a/src/MarkdownToDocxGenerator.UnitTests/Usings.cs
+++ b/src/MarkdownToDocxGenerator.UnitTests/Usings.cs
@@ -1,1 +1,5 @@
 global using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+// Tests share on-disk fixtures (template + MdFiles) and produce documents, so run
+// them serially. Explicit choice required by the MSTEST0001 analyzer.
+[assembly: DoNotParallelize]

--- a/src/MarkdownToDocxGenerator/MarkdownToDocxGenerator.csproj
+++ b/src/MarkdownToDocxGenerator/MarkdownToDocxGenerator.csproj
@@ -24,9 +24,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Markdig" Version="0.42.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0-rc.1.25451.107" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0-rc.1.25451.107" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-rc.1.25451.107" />
-		<PackageReference Include="OpenXMLSDK.Engine" Version="2022.10313.0-preview-044" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+		<PackageReference Include="OpenXMLSDK.Engine" Version="2022.10313.0" />
 	</ItemGroup>
 </Project>

--- a/src/MarkdownToDocxGenerator/MdToOxmlEngine.cs
+++ b/src/MarkdownToDocxGenerator/MdToOxmlEngine.cs
@@ -78,11 +78,14 @@ namespace MarkdownToDocxGenerator
                     var elements = GetContainerInlineText(mdHead.Inline);
                     var paragraph = elements.OfType<Paragraph>().FirstOrDefault();
                     paragraph.ParagraphStyleId = GetTitleStyle(mdHead.Level);
-                    // Now we will delete label styles :
+                    // Now we will delete label styles (including any inline-code
+                    // shading/monospace) so the whole heading inherits the title style :
                     foreach (var label in paragraph.ChildElements.OfType<Label>())
                     {
                         label.FontColor = null;
                         label.FontSize = null;
+                        label.FontName = null;
+                        label.Shading = null;
                     }
                     currentPage.ChildElements.AddRange(elements);
                 }
@@ -234,6 +237,19 @@ namespace MarkdownToDocxGenerator
                     var label = GetLiteralInlineText((LiteralInline)inlineBlock, labelPrefix: labelPrefix);
                     paragraph.ChildElements.Add(label);
                 }
+                else if (blockType == typeof(CodeInline))
+                {
+                    if (paragraph is null)
+                    {
+                        paragraph = new Paragraph()
+                        {
+                            ChildElements = new List<BaseElement>()
+                        };
+                        result.Add(paragraph);
+                    }
+                    var label = GetCodeInlineLabel((CodeInline)inlineBlock);
+                    paragraph.ChildElements.Add(label);
+                }
                 else if (blockType == typeof(EmphasisInline))
                 {
                     if (paragraph is null)
@@ -251,6 +267,11 @@ namespace MarkdownToDocxGenerator
                         if (subBlockType == typeof(LiteralInline))
                         {
                             var label = GetLiteralInlineText((LiteralInline)subBlock, mdEmphasisInline.DelimiterChar == '*' && mdEmphasisInline.DelimiterCount == 2);
+                            paragraph.ChildElements.Add(label);
+                        }
+                        else if (subBlockType == typeof(CodeInline))
+                        {
+                            var label = GetCodeInlineLabel((CodeInline)subBlock);
                             paragraph.ChildElements.Add(label);
                         }
                         else if (subBlockType == typeof(LinkInline))
@@ -534,6 +555,23 @@ namespace MarkdownToDocxGenerator
             return result;
         }
 
+        /// <summary>
+        /// Render an inline <c>`code`</c> span as a monospace, lightly shaded label so
+        /// its content (which may contain markdown-significant characters such as
+        /// apostrophes or pipes) is preserved verbatim rather than dropped.
+        /// </summary>
+        private Label GetCodeInlineLabel(CodeInline codeInline)
+        {
+            return new Label()
+            {
+                Text = codeInline.Content,
+                FontSize = "20",
+                FontName = "Consolas",
+                Shading = "EAEAEA",
+                SpaceProcessingModeValue = SpaceProcessingModeValues.Preserve
+            };
+        }
+
         private BaseElement GetLinkInlineText(LinkInline containerBlock)
         {
             if (containerBlock.IsImage)
@@ -599,14 +637,27 @@ namespace MarkdownToDocxGenerator
                     ChildElements = new List<BaseElement>()
                 };
 
-                if (containerBlock.FirstChild.GetType() == typeof(LiteralInline))
+                var underline = new UnderlineModel
+                {
+                    Color = "40A6DB",
+                    Val = UnderlineValues.Single
+                };
+
+                if (containerBlock.FirstChild == null)
+                {
+                    logger.LogInformation($"Empty link text for {containerBlock.Url}. Skipping hyperlink.");
+                    return null;
+                }
+                else if (containerBlock.FirstChild.GetType() == typeof(LiteralInline))
                 {
                     var label = GetLiteralInlineText((LiteralInline)containerBlock.FirstChild);
-                    label.Underline = new UnderlineModel
-                    {
-                        Color = "40A6DB",
-                        Val = UnderlineValues.Single
-                    };
+                    label.Underline = underline;
+                    hyperlink.Text = label;
+                }
+                else if (containerBlock.FirstChild.GetType() == typeof(CodeInline))
+                {
+                    var label = GetCodeInlineLabel((CodeInline)containerBlock.FirstChild);
+                    label.Underline = underline;
                     hyperlink.Text = label;
                 }
                 else


### PR DESCRIPTION
## Summary

Fixes inline `code` spans being dropped during Markdown → DOCX conversion, moves the runtime dependencies to stable releases, and adds the first focused tests for the engine.

Originally surfaced by a real document whose apostrophes looked "interpreted wrong" — the actual cause was that inline code spans (e.g. `Invalid column name 'X'`) were silently dropped, taking their contents with them.

## What changed

**1. Render inline `code` spans** (`MdToOxmlEngine`)
- `GetContainerInlineText` had no handler for Markdig `CodeInline`, so every inline backtick span was logged as "unknown" and dropped. Now handled at the paragraph level and inside the `EmphasisInline` sub-loop, rendered as a monospace (Consolas), lightly-shaded `Label`. Table cells flow through the same method, so inline code in tables is covered too.
- Inline code in a **heading** now inherits the title style (the heading normalizer also clears `FontName`/`Shading`).
- Inline code as a **link label** (`[`code`](url)`) is preserved.
- Guards a pre-existing `NullReferenceException` on an empty-text absolute link `[](url)`.

**2. Move dependencies to stable**
- `Microsoft.Extensions.*` `10.0.0-rc.1` → `10.0.8`; `OpenXMLSDK.Engine` `2022.10313.0-preview-044` → `2022.10313.0`.
- Removes the `NU5104` pack warning. `netstandard2.0` assets remain present, so .NET Framework / netstandard consumers are unaffected.
- Note: the stable OpenXMLSDK is a separate build from the preview and bumps transitive `Newtonsoft.Json` `13.0.3 → 13.0.4` (same AssemblyVersion; tests pass).

**3. Tests** — first focused mapping tests (heading→`Titre`, bold, code shading, tables, link handling, inline code, empty input) and DI/end-to-end integration tests. Also fixes a README DI example (`RegisterMarkdownToDocxGenerator`, not the non-existent `AddMarkdownToDocxGenerator`).

## Testing

`dotnet build -warnaserror` → 0 warnings, 0 errors. `dotnet test` → **26 passed**.

## Note

A separate PR (#29) fixes a thread-safety issue in the same file, so one of the two will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
