### PR TITLE
Make MdToOxmlEngine thread-safe under singleton registration

### DIFF
--- a/src/MarkdownToDocxGenerator.UnitTests/ThreadSafetyTests.cs
+++ b/src/MarkdownToDocxGenerator.UnitTests/ThreadSafetyTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenXMLSDK.Engine.Word.ReportEngine;
+using OpenXMLSDK.Engine.Word.ReportEngine.Models;
+using OpenXMLSDK.Engine.Word.ReportEngine.Models.ExtendedModels;
+
+namespace MarkdownToDocxGenerator.UnitTests
+{
+    /// <summary>
+    /// The engine is intended to be registered as a singleton
+    /// (RegisterMarkdownToDocxGenerator(asSingleton: true)), so a single instance
+    /// must tolerate concurrent Transform calls. This guards against per-call state
+    /// (e.g. rootFolder) being stored on the instance and racing between threads.
+    /// </summary>
+    [TestClass]
+    public class ThreadSafetyTests
+    {
+        private static Image SingleImage(Report report)
+            => ((Page)report.Document.Pages.Single())
+                .ChildElements.OfType<Paragraph>()
+                .SelectMany(p => p.ChildElements.OfType<Image>())
+                .SingleOrDefault();
+
+        [TestMethod]
+        public void Concurrent_Transform_calls_resolve_images_against_their_own_rootFolder()
+        {
+            // Two distinct root folders, each containing the same relative image name.
+            var folderA = Directory.CreateDirectory(
+                Path.Combine(Path.GetTempPath(), "md2docx_" + Guid.NewGuid().ToString("N"))).FullName;
+            var folderB = Directory.CreateDirectory(
+                Path.Combine(Path.GetTempPath(), "md2docx_" + Guid.NewGuid().ToString("N"))).FullName;
+            try
+            {
+                File.WriteAllBytes(Path.Combine(folderA, "img.png"), Array.Empty<byte>());
+                File.WriteAllBytes(Path.Combine(folderB, "img.png"), Array.Empty<byte>());
+
+                // Large document so the AST walk (which reads rootFolder near the end,
+                // at the image) stays in flight long enough for a concurrent call to
+                // clobber a shared rootFolder field — widening the race window.
+                var filler = string.Join("\n\n", Enumerable.Range(0, 1500).Select(i => $"Paragraph number {i} with some text."));
+                var markdown = filler + "\n\n![](img.png)";
+
+                var engine = new MdToOxmlEngine(NullLogger<MdToOxmlEngine>.Instance); // ONE shared instance
+                var folders = new[] { folderA, folderB };
+                var failures = new ConcurrentBag<string>();
+
+                Parallel.For(0, 300, new ParallelOptions { MaxDegreeOfParallelism = 16 }, i =>
+                {
+                    var folder = folders[i % 2];
+                    var report = engine.Transform(markdown, folder);
+                    var image = SingleImage(report);
+                    if (image is null)
+                        failures.Add($"iter {i}: no image produced (folder {folder})");
+                    else if (!image.Path.StartsWith(folder, StringComparison.Ordinal))
+                        failures.Add($"iter {i}: expected image under {folder}, got {image.Path}");
+                });
+
+                Assert.IsEmpty(failures,
+                    $"{failures.Count} concurrent call(s) resolved the image against the wrong rootFolder. " +
+                    "First few: " + string.Join(" ; ", failures.Take(3)));
+            }
+            finally
+            {
+                Directory.Delete(folderA, true);
+                Directory.Delete(folderB, true);
+            }
+        }
+    }
+}

--- a/src/MarkdownToDocxGenerator/MdToOxmlEngine.cs
+++ b/src/MarkdownToDocxGenerator/MdToOxmlEngine.cs
@@ -23,8 +23,6 @@ namespace MarkdownToDocxGenerator
     {
         private readonly ILogger logger;
 
-        private string rootFolder;
-
         public MdToOxmlEngine(ILogger<MdToOxmlEngine> logger)
         {
             this.logger = logger;
@@ -51,8 +49,6 @@ namespace MarkdownToDocxGenerator
         public Report Transform(string fileContent, 
                                 string rootFolder)
         {
-            this.rootFolder = rootFolder;
-
             var result = new Report()
             {
                 ContextModel = new ContextModel(),
@@ -75,7 +71,7 @@ namespace MarkdownToDocxGenerator
                     // Add title :
                     var mdHead = (HeadingBlock)block;
 
-                    var elements = GetContainerInlineText(mdHead.Inline);
+                    var elements = GetContainerInlineText(mdHead.Inline, rootFolder);
                     var paragraph = elements.OfType<Paragraph>().FirstOrDefault();
                     paragraph.ParagraphStyleId = GetTitleStyle(mdHead.Level);
                     // Now we will delete label styles :
@@ -90,7 +86,7 @@ namespace MarkdownToDocxGenerator
                 {
                     var mdParagraph = (ParagraphBlock)block;
 
-                    var elements = GetContainerInlineText(mdParagraph.Inline);
+                    var elements = GetContainerInlineText(mdParagraph.Inline, rootFolder);
                     currentPage.ChildElements.AddRange(elements);
                 }
                 else if (blockType == typeof(FencedCodeBlock))
@@ -103,7 +99,7 @@ namespace MarkdownToDocxGenerator
                 else if (blockType == typeof(ListBlock))
                 {
                     var mdListBlock = (ListBlock)block;
-                    var paragraphs = GetListBlock(mdListBlock);
+                    var paragraphs = GetListBlock(mdListBlock, rootFolder);
                     currentPage.ChildElements.AddRange(paragraphs);
                 }
                 else if (blockType == typeof(LinkReferenceDefinitionGroup))
@@ -122,7 +118,7 @@ namespace MarkdownToDocxGenerator
                 else if (blockType == typeof(Markdig.Extensions.Tables.Table))
                 {
                     var mdtable = (Markdig.Extensions.Tables.Table)block;
-                    var table = GetTable(mdtable);
+                    var table = GetTable(mdtable, rootFolder);
                     currentPage.ChildElements.Add(table);
                 }
                 else
@@ -144,7 +140,7 @@ namespace MarkdownToDocxGenerator
             return $"Titre{level}";
         }
 
-        private List<BaseElement> GetListBlock(ListBlock block)
+        private List<BaseElement> GetListBlock(ListBlock block, string rootFolder)
         {
             var result = new List<BaseElement>();
             var count = 1;
@@ -158,7 +154,7 @@ namespace MarkdownToDocxGenerator
                         prefix = count.ToString() + ".";
                     else
                         prefix = block.BulletType.ToString();
-                    var elements = GetContainerInlineText(((ParagraphBlock)mdBlock.LastChild).Inline, prefix + " ");
+                    var elements = GetContainerInlineText(((ParagraphBlock)mdBlock.LastChild).Inline, rootFolder, prefix + " ");
                     result.AddRange(elements);
                 }
                 count++;
@@ -212,7 +208,7 @@ namespace MarkdownToDocxGenerator
             return result;
         }
 
-        private List<BaseElement> GetContainerInlineText(ContainerInline containerBlock, string labelPrefix = "")
+        private List<BaseElement> GetContainerInlineText(ContainerInline containerBlock, string rootFolder, string labelPrefix = "")
         {
             var result = new List<BaseElement>();
 
@@ -256,7 +252,7 @@ namespace MarkdownToDocxGenerator
                         else if (subBlockType == typeof(LinkInline))
                         {
                             var mdLinkInline = (LinkInline)subBlock;
-                            var hyperlink = GetLinkInlineText(mdLinkInline);
+                            var hyperlink = GetLinkInlineText(mdLinkInline, rootFolder);
                             if (hyperlink != null)
                                 paragraph.ChildElements.Add(hyperlink);
                         }
@@ -277,7 +273,7 @@ namespace MarkdownToDocxGenerator
                         result.Add(paragraph);
                     }
                     var mdLinkInline = (LinkInline)inlineBlock;
-                    var hyperlink = GetLinkInlineText(mdLinkInline);
+                    var hyperlink = GetLinkInlineText(mdLinkInline, rootFolder);
                     if (hyperlink != null)
                         paragraph.ChildElements.Add(hyperlink);
                 }
@@ -316,9 +312,9 @@ namespace MarkdownToDocxGenerator
             return result;
         }
 
-        private Table GetTable(Markdig.Extensions.Tables.Table table)
+        private Table GetTable(Markdig.Extensions.Tables.Table table, string rootFolder)
         {
-            var cells = GetCells(table);
+            var cells = GetCells(table, rootFolder);
 
             return GenerateTable(cells);
         }
@@ -432,7 +428,7 @@ namespace MarkdownToDocxGenerator
             return cells;
         }
 
-        private List<List<Cell>> GetCells(Markdig.Extensions.Tables.Table table)
+        private List<List<Cell>> GetCells(Markdig.Extensions.Tables.Table table, string rootFolder)
         {
             List<List<Cell>> cells = new List<List<Cell>>();
 
@@ -446,7 +442,7 @@ namespace MarkdownToDocxGenerator
 
                     if (mdParagraph != null)
                     {
-                        var elements = GetContainerInlineText(mdParagraph.Inline);
+                        var elements = GetContainerInlineText(mdParagraph.Inline, rootFolder);
                         var cell = new Cell
                         {
                             Margin = new MarginModel { Left = 100 },
@@ -534,7 +530,7 @@ namespace MarkdownToDocxGenerator
             return result;
         }
 
-        private BaseElement GetLinkInlineText(LinkInline containerBlock)
+        private BaseElement GetLinkInlineText(LinkInline containerBlock, string rootFolder)
         {
             if (containerBlock.IsImage)
             {


### PR DESCRIPTION
## Summary

`MdToOxmlEngine` is intended to be registered as a **singleton** (`RegisterMarkdownToDocxGenerator(asSingleton: true)`, which the Console front-end uses), but it isn't thread-safe: `Transform()` stores the per-call `rootFolder` in an **instance field** and reads it back later during the AST walk (relative image-path resolution in `GetLinkInlineText`).

Under concurrent use, two `Transform()` calls race on that field — one call can resolve its images against the `rootFolder` set by another in-flight call, producing **wrong or dropped images**.

This is the thread-safety item raised in the review PR #27.

## Fix

Remove the `rootFolder` field and thread it as a parameter through `GetContainerInlineText` / `GetListBlock` / `GetTable` / `GetCells` / `GetLinkInlineText`. With no shared mutable per-call state, a single engine instance is safe to share across threads. Pure refactor — no behavioural change for single-threaded callers, no public API change.

## Testing

Added a regression test that drives **one shared engine instance** with 300 concurrent `Transform` calls across two folders (image placed at the end of a large document to widen the race window) and asserts each call resolves its image against its own folder.

- Before the fix: ~140 of 300 calls resolved against the **wrong** folder.
- After the fix: **0**.

`dotnet test` → all green.

## Note

This touches the same methods as #28 (inline-code rendering), so whichever of the two merges first, the other will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
